### PR TITLE
Fixes regarding the MIC-only security levels.

### DIFF
--- a/openstack/02a-MAClow/IEEE802154_security.c
+++ b/openstack/02a-MAClow/IEEE802154_security.c
@@ -300,10 +300,10 @@ owerror_t IEEE802154security_outgoingFrameSecurity(OpenQueueEntry_t*   msg){
       case ASH_SLF_TYPE_MIC_32:  // authentication only cases
       case ASH_SLF_TYPE_MIC_64:
       case ASH_SLF_TYPE_MIC_128: 
-         a = msg->payload;    // first byte of the frame
-         len_a = msg->length; // whole frame
-         m = msg->payload;    // we don't care
-         len_m = 0;           // length of the encrypted part
+         a = msg->payload;             // first byte of the frame
+         len_a = msg->length;          // whole frame
+         m = &msg->payload[len_a];     // concatenate MIC at the end of the frame
+         len_m = 0;                    // length of the encrypted part
          break;
     case ASH_SLF_TYPE_CRYPTO_MIC32:  // authentication + encryption cases
     case ASH_SLF_TYPE_CRYPTO_MIC64:
@@ -531,10 +531,10 @@ owerror_t IEEE802154security_incomingFrame(OpenQueueEntry_t*      msg){
       case ASH_SLF_TYPE_MIC_32:  // authentication only cases
       case ASH_SLF_TYPE_MIC_64:
       case ASH_SLF_TYPE_MIC_128: 
-         a = msg->payload;    // first byte of the frame
-         len_a = msg->length; // whole frame
-         m = msg->payload;    // we don't care
-         len_m = 0;           // length of the encrypted part
+         a = msg->payload;                                           // first byte of the frame
+         len_a = msg->length;                                        // whole frame
+         m = &msg->payload[len_a - msg->l2_authenticationLength];    // MIC is at the end of the frame
+         len_m = msg->l2_authenticationLength;                       // length of the encrypted part
          break;
       case ASH_SLF_TYPE_CRYPTO_MIC32:  // authentication + encryption cases
       case ASH_SLF_TYPE_CRYPTO_MIC64:

--- a/openstack/02a-MAClow/IEEE802154_security.h
+++ b/openstack/02a-MAClow/IEEE802154_security.h
@@ -28,8 +28,20 @@
 
 //=========================== define ==========================================
 
-#define MAXNUMKEYS           MAXNUMNEIGHBORS+1
+#ifdef L2_SECURITY_ACTIVE
+// TODO use parameters passed by SCons
+#define IEEE802154E_SECURITY_LEVEL           ASH_SLF_TYPE_CRYPTO_MIC32
+#define IEEE802154E_SECURITY_LEVEL_BEACON    ASH_SLF_TYPE_MIC_32
+#define IEEE802154E_SECURITY_KEYIDMODE       ASH_KEYIDMODE_DEFAULTKEYSOURCE
+#define IEEE802154E_SECURITY_KEY_INDEX       1
+#else
+#define IEEE802154E_SECURITY_LEVEL           ASH_SLF_TYPE_NOSEC
+#define IEEE802154E_SECURITY_LEVEL_BEACON    ASH_SLF_TYPE_NOSEC 
+#define IEEE802154E_SECURITY_KEYIDMODE       0
+#define IEEE802154E_SECURITY_KEY_INDEX       0
+#endif // L2_SECURITY_ACTIVE
 
+#define MAXNUMKEYS           MAXNUMNEIGHBORS+1
 
 enum Auxiliary_Security_Header_scf_enums{ //Security Control Field
    ASH_SCF_SECURITY_LEVEL = 0,

--- a/openstack/02b-MAChigh/sixtop.c
+++ b/openstack/02b-MAChigh/sixtop.c
@@ -461,16 +461,6 @@ owerror_t sixtop_send(OpenQueueEntry_t *msg) {
    msg->owner        = COMPONENT_SIXTOP;
    msg->l2_frameType = IEEE154_TYPE_DATA;
 
-#ifdef L2_SECURITY_ACTIVE
-// TODO use parameters passed by SCons
-#define IEEE802154E_SECURITY_LEVEL           ASH_SLF_TYPE_CRYPTO_MIC32
-#define IEEE802154E_SECURITY_KEYIDMODE       ASH_KEYIDMODE_DEFAULTKEYSOURCE
-#define IEEE802154E_SECURITY_KEY_INDEX       1
-#else
-#define IEEE802154E_SECURITY_LEVEL           ASH_SLF_TYPE_NOSEC
-#define IEEE802154E_SECURITY_KEYIDMODE       0
-#define IEEE802154E_SECURITY_KEY_INDEX       0
-#endif // L2_SECURITY_ACTIVE
 
    // set l2-security attributes
    msg->l2_securityLevel   = IEEE802154E_SECURITY_LEVEL;
@@ -850,21 +840,9 @@ port_INLINE void sixtop_sendEB() {
    
    //I has an IE in my payload
    eb->l2_IEListPresent = IEEE154_IELIST_YES;
-   
-#ifdef L2_SECURITY_ACTIVE
-// TODO use parameters passed by SCons
-#define IEEE802154E_BEACONS_SECURITY_LEVEL     ASH_SLF_TYPE_MIC_32
-#define IEEE802154E_SECURITY_KEYIDMODE         ASH_KEYIDMODE_DEFAULTKEYSOURCE
-#define IEEE802154E_SECURITY_KEY_INDEX         1
-#else
-#define IEEE802154E_SECURITY_LEVEL             ASH_SLF_TYPE_NOSEC
-#define IEEE802154E_SECURITY_KEYIDMODE         0
-#define IEEE802154E_SECURITY_KEY_INDEX         0
-#endif // L2_SECURITY_ACTIVE
-
 
    // set l2-security attributes
-   eb->l2_securityLevel   = 0;//IEEE802154E_BEACONS_SECURITY_LEVEL;
+   eb->l2_securityLevel   = IEEE802154E_SECURITY_LEVEL_BEACON;
    eb->l2_keyIdMode       = IEEE802154E_SECURITY_KEYIDMODE;
    eb->l2_keyIndex        = IEEE802154E_SECURITY_KEY_INDEX;
 


### PR DESCRIPTION
@ssciancalepore, the problem with MIC-only security levels used for beacons was due to the bug in my code within `IEEE802154_security.c`. It is fixed with this PR and the nodes synchronize with security enabled on beacon frames. Please confirm that it is OK on your side as well. I used `ping6` to inject some data traffic in the network but had to use `-s` option with size of `50` or less as packets do not fit in L2 frame. I don't think there is much we can do about this.

Security configuration is now done within `IEEE802154_security.h` file. 

Some issues that remain:
-  All security-related errors should be logged on the serial port. I think I also introduced a regression during the merge with latest develop such that the Python code does not recognize security errors. `SECURITY_COMPONENT` used to be `0x25` but due to the merge I had to use `0x26` (or similar). This is not reflected in Python.  We should be able to see on the serial port when MIC authentication failed, and similar errors. Could you take a look at this?
- I noticed with sniffer some ACK frames that have security disabled even though most of the ACKs have security enabled. We should investigate what happens there. Let me know if you have an idea.
- Right now, the implementation will accept frames with security disabled, even though appropriate security level is set. We should also fix this soon. 

Great job!
